### PR TITLE
Add name for the SPDX identifier argument

### DIFF
--- a/picknik_ament_copyright/licenses.py
+++ b/picknik_ament_copyright/licenses.py
@@ -32,4 +32,4 @@ from ament_copyright.licenses import read_license_data
 
 TEMPLATE_DIRECTORY = os.path.join(os.path.dirname(__file__), 'template')
 
-picknik_proprietary = read_license_data(TEMPLATE_DIRECTORY, 'PickNik Proprietary License', 'picknik_proprietary')
+picknik_proprietary = read_license_data(TEMPLATE_DIRECTORY, 'PickNik Proprietary License', 'PickNik', 'picknik_proprietary')


### PR DESCRIPTION
Following [this PR](https://github.com/ament/ament_lint/pull/315), packages extending `ament_copyright` need to provide an [SPDX identifier](https://spdx.org/licenses/) for the licenses they add. PickNik's license doesn't actually have a SPDX identifier, but we need to put something in this field anyway. This change is needed to support Rolling.